### PR TITLE
Ruby 3.x. compatibility issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_hubspot (1.0.2)
+    ruby_hubspot (1.0.3)
       faraday
       rake
 

--- a/lib/ruby_hubspot/companies.rb
+++ b/lib/ruby_hubspot/companies.rb
@@ -15,7 +15,7 @@ module Companies
   def create_company(**params)
     validate_access_token
 
-    response(POST, INDIVIDUAL_COMPANY, params)
+    response(POST, INDIVIDUAL_COMPANY, **params)
   end
 
   # shows a company
@@ -34,7 +34,7 @@ module Companies
     params_to_update = params.dup
     params_to_update.delete(:id)
 
-    response(PUT, individual_company_path(params[:id]), params_to_update)
+    response(PUT, individual_company_path(params[:id]), **params_to_update)
   end
 
   # deletes a company

--- a/lib/ruby_hubspot/contacts.rb
+++ b/lib/ruby_hubspot/contacts.rb
@@ -15,7 +15,7 @@ module Contacts
   def create_contact(**params)
     validate_access_token
 
-    response(POST, INDIVIDUAL_CONTACT, params)
+    response(POST, INDIVIDUAL_CONTACT, **params)
   end
 
   # creates or updates a contact
@@ -23,7 +23,7 @@ module Contacts
     validate_access_token
     email_handler(params[:email])
 
-    response(POST, INDIVIDUAL_CONTACT + CREATE_OR_UPDATE + EMAIL + params[:email].to_s, params)
+    response(POST, INDIVIDUAL_CONTACT + CREATE_OR_UPDATE + EMAIL + params[:email].to_s, **params)
   end
 
   # shows a contact
@@ -40,7 +40,7 @@ module Contacts
     params_to_update = params.dup
     params_to_update.delete(:id)
 
-    response(POST, INDIVIDUAL_CONTACT + find_idintificator(params) + PROFILE, params_to_update)
+    response(POST, INDIVIDUAL_CONTACT + find_idintificator(params) + PROFILE, **params_to_update)
   end
 
   # deletes a contact

--- a/lib/ruby_hubspot/hubspot.rb
+++ b/lib/ruby_hubspot/hubspot.rb
@@ -24,7 +24,7 @@ class Hubspot
   def request(http_method, path, **params)
     validate_access_token
 
-    response(http_method, path, params)
+    response(http_method, path, **params)
   end
 
   private
@@ -33,7 +33,7 @@ class Hubspot
     Faraday.send(http_method) do |request|
       request.url(API_URL + path)
       request.headers = headers
-      request.body = body(path, params)
+      request.body = body(path, **params)
     end
   end
 

--- a/lib/ruby_hubspot/version.rb
+++ b/lib/ruby_hubspot/version.rb
@@ -3,5 +3,5 @@
 # Version module
 module RubyHubspot
   # gem version
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end


### PR DESCRIPTION
Refactor 'params' to '**params' for compatibility with Ruby 3.x